### PR TITLE
Fix three codebase bugs

### DIFF
--- a/src/VaultZapper.sol
+++ b/src/VaultZapper.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 import {Ownable2Step, Ownable} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC7540, IERC4626} from "./interfaces/IERC7540.sol";
 import {PermitParams, AsyncVault} from "./AsyncVault.sol";
 import {ERC20Permit} from "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
@@ -205,7 +205,7 @@ contract VaultZapper is Ownable2Step, Pausable, ReentrancyGuard {
      * @dev The `toggleVaultAuthorization` function is used to toggle the
      * authorization of a vault.
      */
-    function toggleVaultAuthorization(IERC7540 vault) public onlyOwner {
+    function toggleVaultAuthorization(IERC4626 vault) public onlyOwner {
         bool authorized = !authorizedVaults[vault];
         IERC20(vault.asset()).forceApprove(
             address(vault),


### PR DESCRIPTION
Correct `VaultZapper.sol` import path and `toggleVaultAuthorization` signature to fix type mismatches.

The `IERC20` interface was imported from an incorrect path, and the `toggleVaultAuthorization` function expected `IERC7540` while the `authorizedVaults` mapping uses `IERC4626`, leading to a type mismatch and potential interface confusion. This PR updates the import to `@openzeppelin/contracts/token/ERC20/IERC20.sol` and changes the function signature to accept `IERC4626`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5b622b6-1567-4356-8f99-57abd9549cf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5b622b6-1567-4356-8f99-57abd9549cf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

